### PR TITLE
Fix issue downloading OSM tiles

### DIFF
--- a/src/com/roots/map/MapPanel.java
+++ b/src/com/roots/map/MapPanel.java
@@ -1939,6 +1939,9 @@ public class MapPanel extends JPanel {
     }
 
     public static void main(String[] args) {
+        // HTTP User-agent is required to be set by OSM Tile Usage Policy to avoid an error.
+        System.setProperty("http.agent", "MapPanel app (https://github.com/srutz/mappanel)");
+	    
         SwingUtilities.invokeLater(new Runnable() {
             public void run() {
                 try {


### PR DESCRIPTION
The user-agent is required now to download OSM tiles.

Was seeing "The tileserver could not be reached." before making this change.

More info about the policy can be found here:

https://operations.osmfoundation.org/policies/tiles/